### PR TITLE
Let HA determine last used brightness instead of Zwave - Proof of Concept

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -48,6 +48,8 @@ from .const import DATA_CLIENT, DOMAIN
 from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
 
+ATTR_LAST_KNOWN_BRIGHTNESS = 'last_known_brightness'
+
 LOGGER = logging.getLogger(__name__)
 
 MULTI_COLOR_MAP = {
@@ -124,6 +126,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             value_property_key=ColorComponent.COLD_WHITE,
         )
         self._supported_color_modes = set()
+        self._last_known_brightness = None
         self._state = False
         self._update_state()
 
@@ -163,6 +166,11 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         if self.supports_brightness_transition or self.supports_color_transition:
             self._attr_supported_features |= SUPPORT_TRANSITION
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose custom attributes."""
+        return {ATTR_LAST_KNOWN_BRIGHTNESS: self._last_known_brightness}
+
     @callback
     def on_value_update(self) -> None:
         """Call when a watched value is added or updated."""
@@ -186,7 +194,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if device is on (brightness above 0)."""
         return self._state
 
     @property
@@ -283,7 +290,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             await self._async_set_colors(rgbw_channels, transition)
 
         # set brightness
-        await self._async_set_brightness(kwargs.get(ATTR_BRIGHTNESS), transition)
+        await self._async_set_brightness(kwargs.get(ATTR_BRIGHTNESS, self._last_known_brightness), transition)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
@@ -350,6 +357,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         self._state = False
         if self.info.primary_value.value is not None:
             self._state = self.info.primary_value.value > 0
+
+        if self.brightness is not None and self.brightness > 0:
+            self._last_known_brightness = self.brightness
 
     @callback
     def _calculate_color_values(self) -> None:


### PR DESCRIPTION
Extend `firstof9`'s work on optimistically setting the state. We maybe would want to put this behind a flag (if we wanted to include it at all!

It tracks any non-zero brightness changes on a separate attribute (which I exposed, but we wouldn't have to), and then when turning on, it will set the brightness of the light to the last known value instead of sending `255` which tells the Zwave device to use its last known brightness. (It will still fall back to doing this if for some reason we don't have a last known brightness value.)

I can't speak to all the zwave issues people have, but this very effectively solves issues with e.g. HomeSeer dimmers that don't report their target state when being set to "last value" (or at least don't set it for 5 seconds/after a poll). The UI now always reflects reality.

This makes for a _much_ better UX.

(Intermediary PR, full summary breakdown will be provided if we move forward from here).